### PR TITLE
feat: 일정 CRUD 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	implementation 'junit:junit:4.13.1'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/zerobase/timate/controller/ScheduleController.java
+++ b/src/main/java/com/zerobase/timate/controller/ScheduleController.java
@@ -1,0 +1,79 @@
+package com.zerobase.timate.controller;
+
+
+import static com.zerobase.timate.type.SuccessCode.DELETE_SUCCESS;
+
+import com.zerobase.timate.dto.ApiResponse;
+import com.zerobase.timate.dto.ScheduleDto;
+import com.zerobase.timate.dto.ScheduleDto.ValidationGroups;
+import com.zerobase.timate.service.AuthService;
+import com.zerobase.timate.service.ScheduleService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/calendars/{calendarId}/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+	private final ScheduleService scheduleService;
+	private final AuthService authService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse> create(
+											@PathVariable Long calendarId,
+											@Validated(ValidationGroups.Create.class)
+											@RequestBody ScheduleDto.Request request) {
+		request.setUserId(authService.getAuthenticatedUserId());
+		request.setCalendarId(calendarId);
+		return ResponseEntity.ok(ApiResponse.success(scheduleService.create(request)));
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse> list(
+											@PathVariable Long calendarId,
+											@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+											@RequestParam String period) {
+		Long userId = authService.getAuthenticatedUserId();
+		return ResponseEntity.ok(
+			ApiResponse.success(scheduleService.getSchedulesByPeriod(userId, calendarId, date, period)));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse> read(@PathVariable Long calendarId, @PathVariable Long id) {
+		Long userId = authService.getAuthenticatedUserId();
+		return ResponseEntity.ok(ApiResponse.success(scheduleService.read(userId, calendarId, id)));
+	}
+
+	@PatchMapping("/{id}")
+	public ResponseEntity<ApiResponse> update(
+												@PathVariable Long calendarId,
+												@PathVariable Long id,
+												@Validated(ValidationGroups.Common.class)
+												@RequestBody ScheduleDto.Request request) {
+		request.setUserId(authService.getAuthenticatedUserId());
+		request.setCalendarId(calendarId);
+		request.setId(id);
+		return ResponseEntity.ok(ApiResponse.success(scheduleService.update(request)));
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<ApiResponse> delete(@PathVariable Long calendarId, @PathVariable Long id) {
+		Long userId = authService.getAuthenticatedUserId();
+		scheduleService.delete(userId, calendarId, id);
+		return ResponseEntity.ok(ApiResponse.success(DELETE_SUCCESS));
+	}
+
+}

--- a/src/main/java/com/zerobase/timate/controller/ScheduleController.java
+++ b/src/main/java/com/zerobase/timate/controller/ScheduleController.java
@@ -6,6 +6,7 @@ import static com.zerobase.timate.type.SuccessCode.DELETE_SUCCESS;
 import com.zerobase.timate.dto.ApiResponse;
 import com.zerobase.timate.dto.ScheduleDto;
 import com.zerobase.timate.dto.ScheduleDto.ValidationGroups;
+import com.zerobase.timate.entity.PeriodType;
 import com.zerobase.timate.service.AuthService;
 import com.zerobase.timate.service.ScheduleService;
 import java.time.LocalDate;
@@ -48,7 +49,7 @@ public class ScheduleController {
 											@RequestParam String period) {
 		Long userId = authService.getAuthenticatedUserId();
 		return ResponseEntity.ok(
-			ApiResponse.success(scheduleService.getSchedulesByPeriod(userId, calendarId, date, period)));
+			ApiResponse.success(scheduleService.getSchedulesByPeriod(userId, calendarId, date, PeriodType.fromString(period))));
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/com/zerobase/timate/dto/CalendarDto.java
+++ b/src/main/java/com/zerobase/timate/dto/CalendarDto.java
@@ -43,11 +43,8 @@ public class CalendarDto {
 	@Builder
 	public static class Response {
 
-		@JsonProperty("id")
 		private Long id;
-		@JsonProperty("name")
 		private String name;
-		@JsonProperty("type")
 		private CalendarType type;
 
 		public static Response from(Calendar calendar) {

--- a/src/main/java/com/zerobase/timate/dto/ScheduleDto.java
+++ b/src/main/java/com/zerobase/timate/dto/ScheduleDto.java
@@ -1,0 +1,110 @@
+package com.zerobase.timate.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zerobase.timate.entity.Schedule;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+public class ScheduleDto {
+
+	public interface ValidationGroups {
+		interface Create {}
+		interface Common {}
+	}
+
+	@Getter
+	@Setter
+	@AllArgsConstructor
+	@Schema(name = "ScheduleRequestDto", description = "일정 요청 DTO")
+	public static class Request {
+
+		private Long id;
+		private Long userId;
+		private Long calendarId;
+
+		@NotNull(message = "제목은 필수 항목입니다.", groups = ValidationGroups.Create.class)
+		private String title;
+		@NotNull(message = "시작일은 필수 항목입니다.", groups = ValidationGroups.Create.class)
+		private LocalDateTime startDate;
+		@NotNull(message = "종료일은 필수 항목입니다.", groups = ValidationGroups.Create.class)
+		private LocalDateTime endDate;
+
+		private String memo;
+
+		private Long googleEventId;
+
+		// 장소 관련
+		private String placeName;
+		private String address;
+		private double latitude;
+		private double longitude;
+
+		@AssertTrue(message = "종료 날짜를 시작 날짜 이전으로 설정할 수 없습니다.",
+					groups = {ValidationGroups.Create.class, ValidationGroups.Common.class})
+		public boolean isEndDateValid() {
+			if (startDate == null || endDate == null) return true;
+			return !startDate.isAfter(endDate);
+		}
+
+	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Response {
+
+		@JsonProperty("id")
+		private Long id;
+		@JsonProperty("creator_id")
+		private Long creatorId;
+		@JsonProperty("calendar_id")
+		private Long calendarId;
+		@JsonProperty("title")
+		private String title;
+		@JsonProperty("start_date")
+		private LocalDateTime startDate;
+		@JsonProperty("end_date")
+		private LocalDateTime endDate;
+		@JsonProperty("memo")
+		private String memo;
+
+		@JsonProperty("place_name")
+		private String placeName;
+		@JsonProperty("address")
+		private String address;
+		@JsonProperty("latitude")
+		private double latitude;
+		@JsonProperty("longitude")
+		private double longitude;
+
+		public static Response from(Schedule schedule) {
+			return Response.builder()
+				.id(schedule.getId())
+				.creatorId(schedule.getCreatorId())
+				.calendarId(schedule.getCalendar().getId())
+				.title(schedule.getTitle())
+				.startDate(schedule.getStartDate())
+				.endDate(schedule.getEndDate())
+				.memo(schedule.getMemo())
+				.placeName(schedule.getPlaceName())
+				.address(schedule.getAddress())
+				.latitude(schedule.getLatitude())
+				.longitude(schedule.getLongitude())
+				.build();
+		}
+
+	}
+
+}

--- a/src/main/java/com/zerobase/timate/dto/ScheduleDto.java
+++ b/src/main/java/com/zerobase/timate/dto/ScheduleDto.java
@@ -65,28 +65,17 @@ public class ScheduleDto {
 	@Builder
 	public static class Response {
 
-		@JsonProperty("id")
 		private Long id;
-		@JsonProperty("creator_id")
 		private Long creatorId;
-		@JsonProperty("calendar_id")
 		private Long calendarId;
-		@JsonProperty("title")
 		private String title;
-		@JsonProperty("start_date")
 		private LocalDateTime startDate;
-		@JsonProperty("end_date")
 		private LocalDateTime endDate;
-		@JsonProperty("memo")
 		private String memo;
 
-		@JsonProperty("place_name")
 		private String placeName;
-		@JsonProperty("address")
 		private String address;
-		@JsonProperty("latitude")
 		private double latitude;
-		@JsonProperty("longitude")
 		private double longitude;
 
 		public static Response from(Schedule schedule) {

--- a/src/main/java/com/zerobase/timate/dto/UserCalendarDto.java
+++ b/src/main/java/com/zerobase/timate/dto/UserCalendarDto.java
@@ -37,15 +37,10 @@ public class UserCalendarDto {
 	@Builder
 	public static class Response {
 
-		@JsonProperty("calendar_id")
 		private Long calendarId;
-		@JsonProperty("calendar_name")
 		private String calendarName;
-		@JsonProperty("user_id")
 		private Long userId;
-		@JsonProperty("user_name")
 		private String userName;
-		@JsonProperty("role")
 		private MemberRole role;
 
 		public static Response from(UserCalendar uc) {

--- a/src/main/java/com/zerobase/timate/dto/UserDto.java
+++ b/src/main/java/com/zerobase/timate/dto/UserDto.java
@@ -31,11 +31,8 @@ public class UserDto {
 	@Builder
 	public static class Response {
 
-		@JsonProperty("id")
 		private Long id;
-		@JsonProperty("email")
 		private String email;
-		@JsonProperty("name")
 		private String name;
 
 		public static Response from(User user) {

--- a/src/main/java/com/zerobase/timate/entity/PeriodType.java
+++ b/src/main/java/com/zerobase/timate/entity/PeriodType.java
@@ -1,0 +1,19 @@
+package com.zerobase.timate.entity;
+
+import static com.zerobase.timate.type.ErrorCode.INVALID_PERIOD;
+
+import com.zerobase.timate.exception.ScheduleException;
+
+public enum PeriodType {
+	DAILY,
+	WEEKLY,
+	MONTHLY;
+
+	public static PeriodType fromString(String period) {
+		try{
+			return PeriodType.valueOf(period.toUpperCase());
+		} catch (Exception e){
+			throw new ScheduleException(INVALID_PERIOD);
+		}
+	}
+}

--- a/src/main/java/com/zerobase/timate/entity/Schedule.java
+++ b/src/main/java/com/zerobase/timate/entity/Schedule.java
@@ -1,6 +1,7 @@
 package com.zerobase.timate.entity;
 
 
+import com.zerobase.timate.dto.ScheduleDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -52,5 +53,15 @@ public class Schedule {
   @JoinColumn(name = "calendar_id")
   private Calendar calendar;
 
+  public static Schedule of(ScheduleDto.Request dto, Calendar calendar) {
+    return Schedule.builder()
+			.creatorId(dto.getUserId())
+			.calendar(calendar)
+			.title(dto.getTitle())
+			.startDate(dto.getStartDate())
+			.endDate(dto.getEndDate())
+			.memo(dto.getMemo())
+			.build();
+  }
 
 }

--- a/src/main/java/com/zerobase/timate/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zerobase/timate/exception/GlobalExceptionHandler.java
@@ -46,6 +46,13 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.badRequest().body(ApiResponse.error(e.getErrorCode()));
 	}
 
+	@ExceptionHandler(ScheduleException.class)
+	public ResponseEntity<ApiResponse> handleScheduleException(ScheduleException e){
+		log.error("{} is ScheduleException occurred.", e.getErrorMessage(), e);
+
+		return ResponseEntity.badRequest().body(ApiResponse.error(e.getErrorCode()));
+	}
+
 	// DTO 유효성 검사 실패 예외 처리
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ApiResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){

--- a/src/main/java/com/zerobase/timate/exception/ScheduleException.java
+++ b/src/main/java/com/zerobase/timate/exception/ScheduleException.java
@@ -1,0 +1,25 @@
+package com.zerobase.timate.exception;
+
+import com.zerobase.timate.dto.UserDto;
+import com.zerobase.timate.type.ErrorCode;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class ScheduleException extends RuntimeException{
+	private ErrorCode errorCode;
+	private String errorMessage;
+	private List<UserDto.Response> members;
+
+	public ScheduleException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+		this.errorMessage = errorCode.getMessage();
+	}
+
+}

--- a/src/main/java/com/zerobase/timate/repository/ScheduleRepository.java
+++ b/src/main/java/com/zerobase/timate/repository/ScheduleRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.timate.repository;
+
+import com.zerobase.timate.entity.Schedule;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+	List<Schedule> findByCalendarIdAndStartDateBetween(Long calendarId, LocalDateTime startDate, LocalDateTime endDate);
+
+}

--- a/src/main/java/com/zerobase/timate/service/CalendarMemberService.java
+++ b/src/main/java/com/zerobase/timate/service/CalendarMemberService.java
@@ -83,7 +83,7 @@ public class CalendarMemberService {
 		Calendar calendar = userCalendar.getCalendar();
 
 		// 관리자라면
-		if (userCalendar.getRole().equals(MemberRole.MASTER)) {
+		if (userCalendar.getRole() == MemberRole.MASTER) {
 			// 멤버 수 확인 (권한 양도를 위해서)
 			List<UserCalendar> members = userCalendarRepository.findMembersExceptSelf(calendar.getId(), userId);
 

--- a/src/main/java/com/zerobase/timate/service/CalendarService.java
+++ b/src/main/java/com/zerobase/timate/service/CalendarService.java
@@ -51,7 +51,7 @@ public class CalendarService {
 	}
 
 	public List<CalendarDto.Response> list(Long userId) {
-		List<UserCalendar> userCalendars = userCalendarRepository.findByUserId(userId);
+		List<UserCalendar> userCalendars = userCalendarRepository.findUserCalendarsWithCalendars(userId);
 
 		return userCalendars.stream()
 			.map(userCalendar -> CalendarDto.Response.from(userCalendar.getCalendar()))

--- a/src/main/java/com/zerobase/timate/service/ScheduleService.java
+++ b/src/main/java/com/zerobase/timate/service/ScheduleService.java
@@ -1,0 +1,135 @@
+package com.zerobase.timate.service;
+
+import static com.zerobase.timate.type.ErrorCode.INVALID_PERIOD;
+import static com.zerobase.timate.type.ErrorCode.SCHEDULE_NOT_FOUND;
+
+import com.zerobase.timate.dto.ScheduleDto;
+import com.zerobase.timate.dto.ScheduleDto.Response;
+import com.zerobase.timate.entity.Calendar;
+import com.zerobase.timate.entity.Schedule;
+import com.zerobase.timate.entity.UserCalendar;
+import com.zerobase.timate.exception.ScheduleException;
+import com.zerobase.timate.repository.ScheduleRepository;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Slf4j
+@org.springframework.stereotype.Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+	private final CommonService commonService;
+
+	private final ScheduleRepository scheduleRepository;
+
+
+	@Transactional
+	public ScheduleDto.Response create(ScheduleDto.Request request) {
+		Long userId = request.getUserId();
+		Long calendarId = request.getCalendarId();
+
+		UserCalendar userCalendar = commonService.getUserCalendar(userId, calendarId);
+		Calendar calendar = userCalendar.getCalendar();
+
+		Schedule schedule = Schedule.builder()
+			.creatorId(userId)
+			.calendar(calendar)
+			.title(request.getTitle())
+			.startDate(request.getStartDate())
+			.endDate(request.getEndDate())
+			// 아래 필수값이 아닌 것들은 값이 있는지 체크 한 후 저장할지
+			.memo(request.getMemo())
+			.build();
+		// TODO: 장소 추가
+		scheduleRepository.save(schedule);
+
+		return ScheduleDto.Response.from(schedule);
+	}
+
+	public Map<?, List<Response>> getSchedulesByPeriod(
+		Long userId, Long calendarId, LocalDate referenceDate, String period) {
+
+		commonService.checkCalendarMember(userId, calendarId);
+
+		LocalDate startDate;
+		LocalDate endDate;
+
+		switch (period.toLowerCase()) {
+			case "monthly": // 월간 조회
+				startDate = referenceDate.withDayOfMonth(1);
+				endDate = referenceDate.withDayOfMonth(referenceDate.lengthOfMonth());
+				break;
+			case "weekly": // 주간 조회 (일요일 ~ 토요일 기준)
+				startDate = referenceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+				endDate = startDate.plusDays(6);
+				break;
+			case "daily": // 일일 조회
+				startDate = referenceDate;
+				endDate = referenceDate;
+				break;
+			default:
+				throw new ScheduleException(INVALID_PERIOD);
+		}
+
+		List<Schedule> schedules = scheduleRepository.findByCalendarIdAndStartDateBetween(
+			calendarId, startDate.atStartOfDay(), endDate.atTime(23, 59, 59));
+		if (period.equals("daily")) {
+			// 시간별로 그룹화
+			return schedules.stream()
+				.map(ScheduleDto.Response::from)
+				.collect(Collectors.groupingBy(
+					schedule -> schedule.getStartDate().withSecond(0).withNano(0),
+					Collectors.toList()
+				));
+		}
+
+		// 날짜별로 그룹화
+		return schedules.stream()
+			.collect(Collectors.groupingBy(
+				schedule -> schedule.getStartDate().toLocalDate(),
+				Collectors.mapping(Response::from, Collectors.toList())
+			));
+	}
+
+	public ScheduleDto.Response read(Long userId, Long calendarId, Long id) {
+		commonService.checkCalendarMember(userId, calendarId);
+
+		return ScheduleDto.Response.from(getScheduleById(id));
+	}
+
+	public ScheduleDto.Response update(ScheduleDto.Request request) {
+		commonService.checkCalendarMember(request.getUserId(), request.getCalendarId());
+
+		Schedule schedule = getScheduleById(request.getId());
+
+		if (request.getTitle() != null) schedule.setTitle(request.getTitle());
+		if (request.getStartDate() != null) schedule.setStartDate(request.getStartDate());
+		if (request.getStartDate() != null) schedule.setEndDate(request.getEndDate());
+		if (request.getMemo() != null) schedule.setMemo(request.getMemo());
+		// TODO : 장소 추가
+
+		scheduleRepository.save(schedule);
+
+		return ScheduleDto.Response.from(schedule);
+	}
+
+	@Transactional
+	public void delete(Long useId, Long calendarId, Long id) {
+		commonService.checkCalendarMaster(useId, calendarId);
+		scheduleRepository.delete(getScheduleById(id));
+	}
+
+	private Schedule getScheduleById(Long id) {
+		return scheduleRepository.findById(id).
+			orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_FOUND));
+	}
+
+}

--- a/src/main/java/com/zerobase/timate/service/ScheduleService.java
+++ b/src/main/java/com/zerobase/timate/service/ScheduleService.java
@@ -39,16 +39,8 @@ public class ScheduleService {
 		UserCalendar userCalendar = commonService.getUserCalendar(userId, calendarId);
 		Calendar calendar = userCalendar.getCalendar();
 
-		Schedule schedule = Schedule.builder()
-			.creatorId(userId)
-			.calendar(calendar)
-			.title(request.getTitle())
-			.startDate(request.getStartDate())
-			.endDate(request.getEndDate())
-			// 아래 필수값이 아닌 것들은 값이 있는지 체크 한 후 저장할지
-			.memo(request.getMemo())
-			.build();
-		// TODO: 장소 추가
+		Schedule schedule = Schedule.of(request, calendar);
+		// TODO: 장소, To-do 추가
 		scheduleRepository.save(schedule);
 
 		return ScheduleDto.Response.from(schedule);
@@ -105,6 +97,7 @@ public class ScheduleService {
 		return ScheduleDto.Response.from(getScheduleById(id));
 	}
 
+	@Transactional
 	public ScheduleDto.Response update(ScheduleDto.Request request) {
 		commonService.checkCalendarMember(request.getUserId(), request.getCalendarId());
 
@@ -114,7 +107,7 @@ public class ScheduleService {
 		if (request.getStartDate() != null) schedule.setStartDate(request.getStartDate());
 		if (request.getStartDate() != null) schedule.setEndDate(request.getEndDate());
 		if (request.getMemo() != null) schedule.setMemo(request.getMemo());
-		// TODO : 장소 추가
+		// TODO: 장소, To-do 추가
 
 		scheduleRepository.save(schedule);
 

--- a/src/main/java/com/zerobase/timate/service/ScheduleService.java
+++ b/src/main/java/com/zerobase/timate/service/ScheduleService.java
@@ -1,11 +1,13 @@
 package com.zerobase.timate.service;
 
+import static com.zerobase.timate.entity.PeriodType.DAILY;
 import static com.zerobase.timate.type.ErrorCode.INVALID_PERIOD;
 import static com.zerobase.timate.type.ErrorCode.SCHEDULE_NOT_FOUND;
 
 import com.zerobase.timate.dto.ScheduleDto;
 import com.zerobase.timate.dto.ScheduleDto.Response;
 import com.zerobase.timate.entity.Calendar;
+import com.zerobase.timate.entity.PeriodType;
 import com.zerobase.timate.entity.Schedule;
 import com.zerobase.timate.entity.UserCalendar;
 import com.zerobase.timate.exception.ScheduleException;
@@ -18,6 +20,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -46,34 +49,33 @@ public class ScheduleService {
 		return ScheduleDto.Response.from(schedule);
 	}
 
+	public Pair<LocalDate, LocalDate> getStartDateAndEndDate(LocalDate referenceDate, PeriodType period) {
+		return switch(period){
+			case  MONTHLY ->  // 월간 조회
+				Pair.of(referenceDate.withDayOfMonth(1), referenceDate.withDayOfMonth(referenceDate.lengthOfMonth()));
+			case WEEKLY -> { // 주간 조회 (일요일 ~ 토요일 기준)
+				LocalDate startWeek = referenceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+				yield Pair.of(startWeek, startWeek.plusDays(6));
+			}
+			case DAILY -> // 일일 조회
+				Pair.of(referenceDate, referenceDate);
+			default -> throw new ScheduleException(INVALID_PERIOD);
+		};
+	}
+
 	public Map<?, List<Response>> getSchedulesByPeriod(
-		Long userId, Long calendarId, LocalDate referenceDate, String period) {
+		Long userId, Long calendarId, LocalDate referenceDate, PeriodType period) {
 
 		commonService.checkCalendarMember(userId, calendarId);
 
-		LocalDate startDate;
-		LocalDate endDate;
-
-		switch (period.toLowerCase()) {
-			case "monthly": // 월간 조회
-				startDate = referenceDate.withDayOfMonth(1);
-				endDate = referenceDate.withDayOfMonth(referenceDate.lengthOfMonth());
-				break;
-			case "weekly": // 주간 조회 (일요일 ~ 토요일 기준)
-				startDate = referenceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
-				endDate = startDate.plusDays(6);
-				break;
-			case "daily": // 일일 조회
-				startDate = referenceDate;
-				endDate = referenceDate;
-				break;
-			default:
-				throw new ScheduleException(INVALID_PERIOD);
-		}
+		Pair<LocalDate, LocalDate> pair = getStartDateAndEndDate(referenceDate, period);
+		LocalDate startDate = pair.getLeft();
+		LocalDate endDate = pair.getRight();
 
 		List<Schedule> schedules = scheduleRepository.findByCalendarIdAndStartDateBetween(
 			calendarId, startDate.atStartOfDay(), endDate.atTime(23, 59, 59));
-		if (period.equals("daily")) {
+
+		if (period == DAILY) {
 			// 시간별로 그룹화
 			return schedules.stream()
 				.map(ScheduleDto.Response::from)

--- a/src/main/java/com/zerobase/timate/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/timate/type/ErrorCode.java
@@ -24,7 +24,10 @@ public enum ErrorCode {
 	NOT_CALENDAR_MEMBER("해당 사용자는 이 캘린더의 멤버가 아닙니다."),
 	NOT_CALENDAR_MASTER("해당 사용자는 이 캘린더의 관리자가 아닙니다."),
 	CANNOT_INVITE_TO_PERSONAL_CALENDAR("개인용 캘린더는 멤버를 초대할 수 없습니다."),
-	INVALID_INVITATION_LINK("초대 링크가 만료되었거나 존재하지 않습니다.")
+	INVALID_INVITATION_LINK("초대 링크가 만료되었거나 존재하지 않습니다."),
+
+	SCHEDULE_NOT_FOUND("일정 정보가 존재하지 않습니다."),
+	INVALID_PERIOD("period는 monthly, weekly, 또는 daily 중 하나여야 합니다.")
 	;
 
 	private final String message;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 일정 관련 기능이 구현되지 않음

**TO-BE**
- 일정 CRUD 기능 구현
    - 일정 생성, 조회, 수정, 삭제 기능을 추가
- 기간별 일정 목록 조회
    - date 는 기준 날짜, period 는 monthly, weekly, daily 로 요청 가능 
    - 월간 조회
        - 예시: date = 2025-03-08, period = monthly
        - 조회 범위: 2025-03-01 ~ 2025-03-31 (해당 월의 전체 일정)
    - 주간 조회
        - 예시: date = 2025-03-08 (토요일), period = weekly
        - 조회 범위: 2025-03-02 (일) ~ 2025-03-08 (토) 
    - 일일 조회
        - 예시: date = 2025-03-08, period = daily
        - 조회 범위: 2025-03-08 하루 일정을 시간 별 조회
- GlobalExceptionHandler에 ScheduleException 추가
    - 일정 관련 예외 처리를 전역적으로 관리

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x ] API 테스트  (Postman)
    - 일정 추가 요청
        - 유효성 검사 확인
            - 필수 값: title, startDate, endDate
            - endDate 를 startDate 이전으로 설정할 수 없음
        - 예외 처리
            - 인증되지 않는 JWT 토큰: "로그인 정보가 유효하지 않습니다."
            - 캘린더 멤버가 아님: "해당 사용자는 이 캘린더의 멤버가 아닙니다."
        - 일정 생성 성공 여부 확인
    - 일정 목록 조회 요청
        - 예외 처리
            - 인증되지 않는 JWT 토큰: "로그인 정보가 유효하지 않습니다."
            - 캘린더 멤버가 아님: "해당 사용자는 이 캘린더의 멤버가 아닙니다."
            - 인증되지 않은 period 값:"period는 monthly, weekly, 또는 daily 중 하나여야 합니다."
        - 일정 목록 조회 확인
    - 일정 조회 요청
        - 예외 처리
            - 인증되지 않는 JWT 토큰: "로그인 정보가 유효하지 않습니다."
            - 캘린더 멤버가 아님: "해당 사용자는 이 캘린더의 멤버가 아닙니다."
            - 존재하지 않는 일정: "일정 정보가 존재하지 않습니다."
        - 일정 조회 성공 여부 확인
    - 일정 수정 요청
        - 유효성 검사 확인
            - endDate 를 startDate 이전으로 설정할 수 없음
        - 예외 처리
            - 인증되지 않는 JWT 토큰: "로그인 정보가 유효하지 않습니다."
            - 캘린더 멤버가 아님: "해당 사용자는 이 캘린더의 멤버가 아닙니다."
            - 존재하지 않는 일정: "일정 정보가 존재하지 않습니다."
        - 일정 수정 성공 여부 확인
    - 일정 삭제 요청
        - 예외 처리
            - 인증되지 않는 JWT 토큰: "로그인 정보가 유효하지 않습니다."
            - 캘린더 멤버가 아님: "해당 사용자는 이 캘린더의 멤버가 아닙니다."
        - 일정 삭제 성공 여부 확인