### PR TITLE
feat: 캐싱을 활용한 인증 로직 개선 및 성능 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
+
+	// cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 	implementation 'junit:junit:4.13.1'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/zerobase/timate/config/RedisConfig.java
+++ b/src/main/java/com/zerobase/timate/config/RedisConfig.java
@@ -1,13 +1,26 @@
 package com.zerobase.timate.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
 
 	@Bean
@@ -15,9 +28,56 @@ public class RedisConfig {
 		RedisTemplate<String, Long> template = new RedisTemplate<>();
 		template.setConnectionFactory(connectionFactory);
 		template.setKeySerializer(new StringRedisSerializer()); // 키는 String 으로 직렬화 설정
-		template.setValueSerializer(new GenericToStringSerializer<>(Long.class));  // 값은 Long 타입으로 직렬화 설정
-            // Long 값을 문자열로 변환하여 Redis 에 저장하고, 가져올 때는 다시 Long 객체로 변환
+		template.setValueSerializer(
+			new GenericToStringSerializer<>(Long.class));  // 값은 Long 타입으로 직렬화 설정
+		// Long 값을 문자열로 변환하여 Redis 에 저장하고, 가져올 때는 다시 Long 객체로 변환
 		return template;
 	}
+
+	@Bean
+	public RedisTemplate<String, Object> jsonRedisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());  // Generic JSON 직렬화
+		return template;
+	}
+
+	@Bean
+	// @Cacheable 사용 시 적용되는 설정
+	public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(
+			new JavaTimeModule()); // Java 8 날짜/시간 API 지원 (LocalDate, LocalDateTime 등)
+		objectMapper.activateDefaultTyping(LaissezFaireSubTypeValidator.instance, // 모든 타입을 허용하는 검증기
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			// 타입 정보를 포함할 클래스의 범위를 지정 -> final 이 아닌 모든 클래스에 대해 타입 정보를 추가
+			JsonTypeInfo.As.PROPERTY); // 직렬화된 JSON 에 타입 정보가 별도의 프로퍼티로 추가됨
+		/*
+		activateDefaultTyping() 하는 이유?
+		- activateDefaultTyping()은 ObjectMapper 가 JSON 직렬화/역직렬화 과정에서 객체 타입 정보를 포함하거나 인식하도록 설정하는 메서드이다.
+		- 즉, 직렬화된 JSON 데이터에 객체의 타입 정보(클래스 이름)를 추가하여, 역직렬화 시 원래 객체로 정확하게 변환할 수 있게 하는 설정
+		- Redis 와 같은 외부 저장소에서 객체를 직렬화해서 저장할 때, 객체의 타입 정보가 없으면 역직렬화 시 원래 타입으로 복원하는게 어렵기 때문에 타입 정보 설정해줘야 함.
+		 */
+
+		objectMapper.setVisibility(PropertyAccessor.ALL,
+			JsonAutoDetect.Visibility.ANY); // 모든 필드 (public, private, protected) 를 직렬화 대상으로 설정
+
+		// Redis 직렬화 설정
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(
+			objectMapper);
+		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+				new StringRedisSerializer())) // 값을 JSON 형식으로 직렬화
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+			.entryTtl(Duration.ofMinutes(30)); // 전체 캐시의 기본 TTL (30분)
+
+		// RedisCacheManager 빌더로 캐시 설정 구성
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(config)
+			.build();
+	}
+
 
 }

--- a/src/main/java/com/zerobase/timate/config/RedisConfig.java
+++ b/src/main/java/com/zerobase/timate/config/RedisConfig.java
@@ -35,15 +35,6 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String, Object> jsonRedisTemplate(RedisConnectionFactory connectionFactory) {
-		RedisTemplate<String, Object> template = new RedisTemplate<>();
-		template.setConnectionFactory(connectionFactory);
-		template.setKeySerializer(new StringRedisSerializer());
-		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());  // Generic JSON 직렬화
-		return template;
-	}
-
-	@Bean
 	// @Cacheable 사용 시 적용되는 설정
 	public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -53,6 +44,7 @@ public class RedisConfig {
 			ObjectMapper.DefaultTyping.NON_FINAL,
 			// 타입 정보를 포함할 클래스의 범위를 지정 -> final 이 아닌 모든 클래스에 대해 타입 정보를 추가
 			JsonTypeInfo.As.PROPERTY); // 직렬화된 JSON 에 타입 정보가 별도의 프로퍼티로 추가됨
+
 		/*
 		activateDefaultTyping() 하는 이유?
 		- activateDefaultTyping()은 ObjectMapper 가 JSON 직렬화/역직렬화 과정에서 객체 타입 정보를 포함하거나 인식하도록 설정하는 메서드이다.

--- a/src/main/java/com/zerobase/timate/dto/CalendarDto.java
+++ b/src/main/java/com/zerobase/timate/dto/CalendarDto.java
@@ -23,6 +23,7 @@ public class CalendarDto {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor
 	@AllArgsConstructor
 	@Schema(name = "CalendarRequestDto", description = "캘린더 요청 DTO")
 	public static class Request {

--- a/src/main/java/com/zerobase/timate/dto/CalendarDto.java
+++ b/src/main/java/com/zerobase/timate/dto/CalendarDto.java
@@ -58,4 +58,33 @@ public class CalendarDto {
 
 	}
 
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Cached {
+
+		private Long id;
+		private String name;
+		private CalendarType type;
+
+		public static Cached from(Calendar calendar) {
+			return Cached.builder()
+				.id(calendar.getId())
+				.type(calendar.getType())
+				.name(calendar.getName())
+				.build();
+		}
+
+		public static Calendar toEntity(CalendarDto.Cached calendar) {
+			return Calendar.builder()
+				.id(calendar.getId())
+				.type(calendar.getType())
+				.name(calendar.getName())
+				.build();
+		}
+
+	}
+
 }

--- a/src/main/java/com/zerobase/timate/dto/ScheduleDto.java
+++ b/src/main/java/com/zerobase/timate/dto/ScheduleDto.java
@@ -1,10 +1,8 @@
 package com.zerobase.timate.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zerobase.timate.entity.Calendar;
 import com.zerobase.timate.entity.Schedule;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Column;
-import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -93,6 +91,58 @@ public class ScheduleDto {
 				.longitude(schedule.getLongitude())
 				.build();
 		}
+
+	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Cached {
+
+		private Long id;
+		private Long creatorId;
+		private String title;
+		private LocalDateTime startDate;
+		private LocalDateTime endDate;
+		private String memo;
+
+		private String placeName;
+		private String address;
+		private double latitude;
+		private double longitude;
+
+		private Calendar calendar;
+
+		public static Cached from(Schedule schedule) {
+			return Cached.builder()
+				.id(schedule.getId())
+				.creatorId(schedule.getCreatorId())
+				.calendar(schedule.getCalendar())
+				.title(schedule.getTitle())
+				.startDate(schedule.getStartDate())
+				.endDate(schedule.getEndDate())
+				.memo(schedule.getMemo())
+				.placeName(schedule.getPlaceName())
+				.address(schedule.getAddress())
+				.latitude(schedule.getLatitude())
+				.longitude(schedule.getLongitude())
+				.build();
+		}
+
+	  public static Schedule toEntity(ScheduleDto.Cached dto) {
+		return Schedule.builder()
+			.id(dto.getId())
+			.creatorId(dto.getCreatorId())
+			.calendar(dto.getCalendar())
+			.title(dto.getTitle())
+			.startDate(dto.getStartDate())
+			.endDate(dto.getEndDate())
+			.memo(dto.getMemo())
+			.build();
+	  }
+
 
 	}
 

--- a/src/main/java/com/zerobase/timate/dto/ScheduleDto.java
+++ b/src/main/java/com/zerobase/timate/dto/ScheduleDto.java
@@ -22,6 +22,7 @@ public class ScheduleDto {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor
 	@AllArgsConstructor
 	@Schema(name = "ScheduleRequestDto", description = "일정 요청 DTO")
 	public static class Request {

--- a/src/main/java/com/zerobase/timate/entity/Schedule.java
+++ b/src/main/java/com/zerobase/timate/entity/Schedule.java
@@ -56,13 +56,14 @@ public class Schedule {
 
   public static Schedule of(ScheduleDto.Request dto, Calendar calendar) {
     return Schedule.builder()
-			.creatorId(dto.getUserId())
-			.calendar(calendar)
-			.title(dto.getTitle())
-			.startDate(dto.getStartDate())
-			.endDate(dto.getEndDate())
-			.memo(dto.getMemo())
-			.build();
+		.creatorId(dto.getUserId())
+		.calendar(calendar)
+		.title(dto.getTitle())
+		.startDate(dto.getStartDate())
+		.endDate(dto.getEndDate())
+		.memo(dto.getMemo())
+		.build();
   }
+
 
 }

--- a/src/main/java/com/zerobase/timate/entity/Schedule.java
+++ b/src/main/java/com/zerobase/timate/entity/Schedule.java
@@ -2,6 +2,7 @@ package com.zerobase.timate.entity;
 
 
 import com.zerobase.timate.dto.ScheduleDto;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -49,7 +50,7 @@ public class Schedule {
   private double longitude;
 
 
-  @ManyToOne
+  @ManyToOne(cascade = CascadeType.MERGE)
   @JoinColumn(name = "calendar_id")
   private Calendar calendar;
 

--- a/src/main/java/com/zerobase/timate/entity/UserCalendar.java
+++ b/src/main/java/com/zerobase/timate/entity/UserCalendar.java
@@ -43,7 +43,7 @@ public class UserCalendar {
 
   public static UserCalendar of(User user, Calendar calendar, MemberRole role) {
     return UserCalendar.builder()
-        .id(new UserCalendarId(calendar.getId(), user.getId())) // 복합키를 명시적으로 설정
+        .id(new UserCalendarId(user.getId(), calendar.getId())) // 복합키를 명시적으로 설정
         .user(user)
         .calendar(calendar)
         .role(role)

--- a/src/main/java/com/zerobase/timate/repository/ScheduleRepository.java
+++ b/src/main/java/com/zerobase/timate/repository/ScheduleRepository.java
@@ -3,9 +3,12 @@ package com.zerobase.timate.repository;
 import com.zerobase.timate.entity.Schedule;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 	List<Schedule> findByCalendarIdAndStartDateBetween(Long calendarId, LocalDateTime startDate, LocalDateTime endDate);
+	boolean existsByIdAndCalendarId(Long id, Long calendarId);
+	Optional<Schedule> findByIdAndCalendarId(Long id, Long calendarId);
 
 }

--- a/src/main/java/com/zerobase/timate/service/CalendarMemberService.java
+++ b/src/main/java/com/zerobase/timate/service/CalendarMemberService.java
@@ -46,7 +46,7 @@ public class CalendarMemberService {
 
 		log.info("캘린더 멤버 추가 요청 - userId: {}, calendarId: {}", userId, calendarId);
 		User user = commonService.getUserById(userId);
-		Calendar calendar = calendarService.getCalendarById(calendarId);
+		Calendar calendar = commonService.getCalendarById(calendarId);
 
 
 		// 이미 초대된 멤버인지 확인
@@ -66,7 +66,7 @@ public class CalendarMemberService {
 
 	public List<UserDto.Response> memberList(Long userId, Long calendarId) {
 		// 해당 캘린더의 멤버인지 확인
-		commonService.checkCalendarMember(userId, calendarId);
+		commonService.validateCalendarMember(userId, calendarId);
 
 		List<UserCalendar> userCalendars = userCalendarRepository.findByCalendarIdWithUser(calendarId);
 
@@ -111,7 +111,7 @@ public class CalendarMemberService {
 		Long newMasterId = request.getNewMasterId();
 
 		// 해당 사용자 권한이 MASTER 인지 확인
-		commonService.checkCalendarMaster(userId, calendarId);
+		commonService.validateCalendarMaster(userId, calendarId);
 
 		changeMaster(userId, newMasterId, calendarId);
 

--- a/src/main/java/com/zerobase/timate/service/CalendarService.java
+++ b/src/main/java/com/zerobase/timate/service/CalendarService.java
@@ -1,5 +1,7 @@
 package com.zerobase.timate.service;
 
+import static com.zerobase.timate.dto.CalendarDto.Cached.toEntity;
+
 import com.zerobase.timate.dto.CalendarDto;
 import com.zerobase.timate.dto.CalendarDto.Request;
 import com.zerobase.timate.entity.Calendar;
@@ -13,7 +15,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,8 +28,6 @@ public class CalendarService {
 	private final CalendarRepository calendarRepository;
 	private final UserCalendarRepository userCalendarRepository;
 
-	private final RedisTemplate<String, Object> redisTemplate;
-
 	@Transactional
 	public CalendarDto.Response create(Request request) {
 		User user = commonService.getUserById(request.getUserId());
@@ -40,7 +39,8 @@ public class CalendarService {
 		UserCalendar userCalendar = UserCalendar.of(user, calendar, MemberRole.MASTER);
 		userCalendarRepository.save(userCalendar);
 
-		return CalendarDto.Response.from(calendar);
+		return CalendarDto.Response.from(
+			toEntity(commonService.getCalendarFromCache(user.getId(), calendar.getId())));
 	}
 
 	public List<CalendarDto.Response> list(Long userId) {
@@ -52,20 +52,13 @@ public class CalendarService {
 	}
 
 	public CalendarDto.Response read(Long userId, Long id) {
-		return CalendarDto.Response.from(commonService.getCalendar(userId, id));
+		return CalendarDto.Response.from(
+			toEntity(commonService.getCalendarFromCache(userId, id)));
 	}
 
 	public CalendarDto.Response update(Request request) {
 		commonService.validateCalendarMaster(request.getUserId(), request.getId());
-
-		Calendar calendar = (commonService.getCalendar(request.getUserId(), request.getId()));
-		calendar.setName(request.getName());
-		calendarRepository.save(calendar);
-
-		// @Cacheable 로 캐시 저장할 때와 반환 값이 달라서 redisTemplate 사용해 캐시 업데이트
-		redisTemplate.opsForValue().set("calendar::" + request.getUserId() + ":" + request.getId(), calendar);
-
-		return CalendarDto.Response.from(calendar);
+		return CalendarDto.Response.from(toEntity(commonService.updateCalendarFromCache(request)));
 	}
 
 	@Transactional
@@ -73,7 +66,7 @@ public class CalendarService {
 	public void delete(Long userId, Long id) {
 		commonService.validateCalendarMaster(userId, id);
 
-		Calendar calendar = commonService.getCalendar(userId, id);
+		Calendar calendar = toEntity(commonService.getCalendarFromCache(userId, id));
 
 		userCalendarRepository.deleteByCalendarId(calendar.getId());
 

--- a/src/main/java/com/zerobase/timate/service/CalendarService.java
+++ b/src/main/java/com/zerobase/timate/service/CalendarService.java
@@ -1,25 +1,24 @@
 package com.zerobase.timate.service;
 
-import static com.zerobase.timate.type.ErrorCode.CALENDAR_NOT_FOUND;
-
 import com.zerobase.timate.dto.CalendarDto;
 import com.zerobase.timate.dto.CalendarDto.Request;
 import com.zerobase.timate.entity.Calendar;
 import com.zerobase.timate.entity.MemberRole;
 import com.zerobase.timate.entity.User;
 import com.zerobase.timate.entity.UserCalendar;
-import com.zerobase.timate.entity.UserCalendarId;
-import com.zerobase.timate.exception.CalendarException;
 import com.zerobase.timate.repository.CalendarRepository;
 import com.zerobase.timate.repository.UserCalendarRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
-@org.springframework.stereotype.Service
+@Service
 @RequiredArgsConstructor
 public class CalendarService {
 
@@ -27,6 +26,8 @@ public class CalendarService {
 
 	private final CalendarRepository calendarRepository;
 	private final UserCalendarRepository userCalendarRepository;
+
+	private final RedisTemplate<String, Object> redisTemplate;
 
 	@Transactional
 	public CalendarDto.Response create(Request request) {
@@ -51,35 +52,33 @@ public class CalendarService {
 	}
 
 	public CalendarDto.Response read(Long userId, Long id) {
-		commonService.checkCalendarMember(userId, id);
-		return CalendarDto.Response.from(getCalendarById(id));
+		return CalendarDto.Response.from(commonService.getCalendar(userId, id));
 	}
 
 	public CalendarDto.Response update(Request request) {
-		commonService.checkCalendarMaster(request.getUserId(), request.getId());
+		commonService.validateCalendarMaster(request.getUserId(), request.getId());
 
-		Calendar calendar = getCalendarById(request.getId());
+		Calendar calendar = (commonService.getCalendar(request.getUserId(), request.getId()));
 		calendar.setName(request.getName());
 		calendarRepository.save(calendar);
+
+		// @Cacheable 로 캐시 저장할 때와 반환 값이 달라서 redisTemplate 사용해 캐시 업데이트
+		redisTemplate.opsForValue().set("calendar::" + request.getUserId() + ":" + request.getId(), calendar);
 
 		return CalendarDto.Response.from(calendar);
 	}
 
 	@Transactional
-	public void delete(Long useId, Long id) {
-		commonService.checkCalendarMaster(useId, id);
+	@CacheEvict(value = "calendar", key = "#userId + ':' + #id")
+	public void delete(Long userId, Long id) {
+		commonService.validateCalendarMaster(userId, id);
 
-		Calendar calendar = getCalendarById(id);
+		Calendar calendar = commonService.getCalendar(userId, id);
 
 		userCalendarRepository.deleteByCalendarId(calendar.getId());
 
 		calendarRepository.deleteById(calendar.getId());
 
-	}
-
-	public Calendar getCalendarById(Long id) {
-		return calendarRepository.findById(id)
-			.orElseThrow(() -> new CalendarException(CALENDAR_NOT_FOUND));
 	}
 
 

--- a/src/main/java/com/zerobase/timate/service/CommonService.java
+++ b/src/main/java/com/zerobase/timate/service/CommonService.java
@@ -1,19 +1,28 @@
 package com.zerobase.timate.service;
 
+import static com.zerobase.timate.type.ErrorCode.CALENDAR_NOT_FOUND;
 import static com.zerobase.timate.type.ErrorCode.NOT_CALENDAR_MASTER;
 import static com.zerobase.timate.type.ErrorCode.NOT_CALENDAR_MEMBER;
+import static com.zerobase.timate.type.ErrorCode.SCHEDULE_NOT_FOUND;
 import static com.zerobase.timate.type.ErrorCode.USER_NOT_FOUND;
 
+import com.zerobase.timate.entity.Calendar;
 import com.zerobase.timate.entity.MemberRole;
+import com.zerobase.timate.entity.Schedule;
 import com.zerobase.timate.entity.User;
 import com.zerobase.timate.entity.UserCalendar;
 import com.zerobase.timate.exception.AuthException;
 import com.zerobase.timate.exception.CalendarException;
+import com.zerobase.timate.exception.ScheduleException;
+import com.zerobase.timate.repository.CalendarRepository;
+import com.zerobase.timate.repository.ScheduleRepository;
 import com.zerobase.timate.repository.UserCalendarRepository;
 import com.zerobase.timate.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -23,71 +32,107 @@ public class CommonService {
 	private final UserRepository userRepository;
 	private final UserCalendarRepository userCalendarRepository;
 
+	private final CalendarRepository calendarRepository;
+	private final ScheduleRepository scheduleRepository;
+
 	public User getUserById(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new AuthException(USER_NOT_FOUND));
 	}
 
+	public Calendar getCalendarById(Long calendarId) {
+		return calendarRepository.findById(calendarId)
+			.orElseThrow(() -> new CalendarException(CALENDAR_NOT_FOUND));
+	}
+
+	@Cacheable(value = "calendar", key = "#userId + ':' + #calendarId")
+	public Calendar getCalendar(Long userId, Long calendarId) {
+		log.info("Calling getCalendar method for userId: {}, calendarId: {}", userId, calendarId);
+		validateCalendarMember(userId, calendarId);
+		return calendarRepository.findById(calendarId)
+			.orElseThrow(() -> new CalendarException(CALENDAR_NOT_FOUND));
+	}
+
 	/**
 	 * 주어진 userId와 calendarId에 해당하는 UserCalendar를 반환합니다.
+	 * <p>
+	 * 이 메소드는 `validateCalendarMember` 메소드를 사용하여 먼저 사용자가 해당 캘린더의 멤버인지 확인한 후, 멤버라면 `UserCalendar`
+	 * 객체를 반환합니다.
+	 * <p>
+	 * 이렇게 메소드를 분리한 이유는 **유지보수성**을 위해서입니다. `validateCalendarMember`는 사용자가 캘린더의 멤버인지 확인하는 독립적인
+	 * 로직이므로, 여러 곳에서 재사용 가능하도록 분리되었습니다.
 	 *
-	 * 이 메소드는 `checkUserCalendarMember` 메소드를 사용하여 먼저 사용자가 해당 캘린더의 멤버인지 확인한 후,
-	 * 멤버라면 `UserCalendar` 객체를 반환합니다.
-	 *
-	 * 이렇게 메소드를 분리한 이유는 **유지보수성**을 위해서입니다. `checkUserCalendarMember`는 사용자가
-	 * 캘린더의 멤버인지 확인하는 독립적인 로직이므로, 여러 곳에서 재사용 가능하도록 분리되었습니다.
-	 *
-	 * @param userId 사용자의 ID
+	 * @param userId     사용자의 ID
 	 * @param calendarId 캘린더의 ID
 	 * @return UserCalendar 해당 사용자의 캘린더 정보
 	 * @throws CalendarException 사용자가 캘린더의 멤버가 아닐 경우 예외 발생
 	 */
 	public UserCalendar getUserCalendar(Long userId, Long calendarId) {
-		checkCalendarMember(userId, calendarId);
-		return userCalendarRepository.findByUserIdAndCalendarId(userId, calendarId).get();
+		validateCalendarMember(userId, calendarId);
+		return userCalendarRepository.findByUserIdAndCalendarId(userId, calendarId)
+			.orElseThrow(() -> new CalendarException(CALENDAR_NOT_FOUND));
+	}
+
+	@Cacheable(value = "schedule", key = "#calendarId + ':' + #scheduleId")
+	public Schedule getSchedule(Long userId, Long calendarId, Long scheduleId) {
+		log.info("Calling getSchedule method for calendarId: {}, scheduleId: {}", calendarId, scheduleId);
+		validateCalendarMember(userId, calendarId);
+		validateSchedule(calendarId, scheduleId);
+		return scheduleRepository.findByIdAndCalendarId(scheduleId, calendarId)
+			.orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_FOUND));
 	}
 
 	/**
 	 * 주어진 userId와 calendarId에 대해 사용자가 해당 캘린더의 멤버인지 확인합니다.
+	 * <p>
+	 * 이 메소드는 `isUserCalendarMember`를 호출하여 캘린더 멤버 여부를 확인하고, 멤버가 아니면 예외를 발생시킵니다.
+	 * <p>
+	 * **유지보수성**을 고려하여 이 메소드를 별도로 분리하였습니다. 이 메소드는 `getUserCalendar`와 같은 다른 메소드에서 재사용이 가능하며, 코드 중복을
+	 * 피하고, 멤버 여부를 확인하는 로직을 독립적으로 관리할 수 있습니다.
 	 *
-	 * 이 메소드는 `isUserCalendarMember`를 호출하여 캘린더 멤버 여부를 확인하고,
-	 * 멤버가 아니면 예외를 발생시킵니다.
-	 *
-	 * **유지보수성**을 고려하여 이 메소드를 별도로 분리하였습니다. 이 메소드는 `getUserCalendar`와 같은 다른
-	 * 메소드에서 재사용이 가능하며, 코드 중복을 피하고, 멤버 여부를 확인하는 로직을 독립적으로 관리할 수 있습니다.
-	 *
-	 * @param userId 사용자의 ID
+	 * @param userId     사용자의 ID
 	 * @param calendarId 캘린더의 ID
 	 * @throws CalendarException 사용자가 캘린더의 멤버가 아니면 예외 발생
 	 */
-	public void checkCalendarMember(Long userId, Long calendarId) {
+	public void validateCalendarMember(Long userId, Long calendarId) {
+		log.info("Calling validateCalendarMember method for userId: {}, calendarId: {}", userId, calendarId);
 		if (!isCalendarMember(userId, calendarId)) {
 			throw new CalendarException(NOT_CALENDAR_MEMBER);
 		}
 	}
 
+	public void validateSchedule(Long calendarId, Long scheduleId) {
+		if (!isScheduleCalendar(calendarId, scheduleId)) {
+			throw new ScheduleException(SCHEDULE_NOT_FOUND);
+		}
+	}
+
 	/**
 	 * 주어진 userId와 calendarId에 대해 사용자가 해당 캘린더의 멤버인지 여부를 확인합니다.
-	 *
+	 * <p>
 	 * 이 메소드는 캘린더의 멤버 여부를 `true` 또는 `false`로 반환합니다.
+	 * <p>
+	 * `validateCalendarMember`와 같은 다른 메소드에서 호출되어 재사용될 수 있도록 별도로 분리되었습니다. **재사용성**을 높이기 위해, 이 메소드는
+	 * 멤버 여부만 단순히 반환하므로 독립적으로 사용될 수 있습니다.
 	 *
-	 * `checkUserCalendarMember`와 같은 다른 메소드에서 호출되어 재사용될 수 있도록 별도로 분리되었습니다.
-	 * **재사용성**을 높이기 위해, 이 메소드는 멤버 여부만 단순히 반환하므로 독립적으로 사용될 수 있습니다.
-	 *
-	 * @param userId 사용자의 ID
+	 * @param userId     사용자의 ID
 	 * @param calendarId 캘린더의 ID
 	 * @return boolean 사용자가 캘린더의 멤버이면 true, 아니면 false
 	 */
 	public boolean isCalendarMember(Long userId, Long calendarId) {
+		log.info("Calling isCalendarMember method for userId: {}, calendarId: {}", userId, calendarId);
 		return userCalendarRepository.existsByUserIdAndCalendarId(userId, calendarId);
 	}
 
-	public void checkCalendarMaster(Long userId, Long calendarId) {
-		UserCalendar userCalendar = getUserCalendar(userId, calendarId);
-		 if (userCalendar.getRole() != MemberRole.MASTER) {
-			 throw new CalendarException(NOT_CALENDAR_MASTER);
-		 }
+	public boolean isScheduleCalendar(Long calendarId, Long scheduleId) {
+		return scheduleRepository.existsByIdAndCalendarId(scheduleId, calendarId);
 	}
 
+	public void validateCalendarMaster(Long userId, Long calendarId) {
+		UserCalendar userCalendar = getUserCalendar(userId, calendarId);
+		if (userCalendar.getRole() != MemberRole.MASTER) {
+			throw new CalendarException(NOT_CALENDAR_MASTER);
+		}
+	}
 
 }

--- a/src/main/java/com/zerobase/timate/service/CommonService.java
+++ b/src/main/java/com/zerobase/timate/service/CommonService.java
@@ -91,7 +91,7 @@ public class CommonService {
 
 	@Cacheable(value = "schedule", key = "#calendarId + ':' + #scheduleId")
 	public ScheduleDto.Cached getScheduleFromCache(Long userId, Long calendarId, Long scheduleId) {
-		log.info("Calling getSchedule method for calendarId: {}, scheduleId: {}", calendarId, scheduleId);
+		log.info("Calling getSchedule method for userId:{}, calendarId: {}, scheduleId: {}", userId, calendarId, scheduleId);
 		validateCalendarMember(userId, calendarId);
 		validateSchedule(calendarId, scheduleId);
 		Schedule schedule = scheduleRepository.findByIdAndCalendarId(scheduleId, calendarId)

--- a/src/main/java/com/zerobase/timate/service/CommonService.java
+++ b/src/main/java/com/zerobase/timate/service/CommonService.java
@@ -1,11 +1,16 @@
 package com.zerobase.timate.service;
 
+import static com.zerobase.timate.dto.CalendarDto.Cached.toEntity;
 import static com.zerobase.timate.type.ErrorCode.CALENDAR_NOT_FOUND;
 import static com.zerobase.timate.type.ErrorCode.NOT_CALENDAR_MASTER;
 import static com.zerobase.timate.type.ErrorCode.NOT_CALENDAR_MEMBER;
 import static com.zerobase.timate.type.ErrorCode.SCHEDULE_NOT_FOUND;
 import static com.zerobase.timate.type.ErrorCode.USER_NOT_FOUND;
 
+import com.zerobase.timate.dto.CalendarDto;
+import com.zerobase.timate.dto.CalendarDto.Request;
+import com.zerobase.timate.dto.ScheduleDto;
+import com.zerobase.timate.dto.ScheduleDto.Cached;
 import com.zerobase.timate.entity.Calendar;
 import com.zerobase.timate.entity.MemberRole;
 import com.zerobase.timate.entity.Schedule;
@@ -20,9 +25,9 @@ import com.zerobase.timate.repository.UserCalendarRepository;
 import com.zerobase.timate.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -46,11 +51,22 @@ public class CommonService {
 	}
 
 	@Cacheable(value = "calendar", key = "#userId + ':' + #calendarId")
-	public Calendar getCalendar(Long userId, Long calendarId) {
-		log.info("Calling getCalendar method for userId: {}, calendarId: {}", userId, calendarId);
+	public CalendarDto.Cached getCalendarFromCache(Long userId, Long calendarId) {
+		log.info("Calling getCalendarFromCache method for userId: {}, calendarId: {}", userId, calendarId);
 		validateCalendarMember(userId, calendarId);
-		return calendarRepository.findById(calendarId)
+		Calendar calendar = calendarRepository.findById(calendarId)
 			.orElseThrow(() -> new CalendarException(CALENDAR_NOT_FOUND));
+		return CalendarDto.Cached.from(calendar);
+	}
+
+	@CachePut(value = "calendar", key = "#request.userId + ':' + #request.id")
+	public CalendarDto.Cached updateCalendarFromCache(Request request) {
+
+		Calendar calendar = toEntity(getCalendarFromCache(request.getUserId(), request.getId()));
+		calendar.setName(request.getName());
+		calendarRepository.save(calendar);
+
+		return CalendarDto.Cached.from(calendar);
 	}
 
 	/**
@@ -74,13 +90,31 @@ public class CommonService {
 	}
 
 	@Cacheable(value = "schedule", key = "#calendarId + ':' + #scheduleId")
-	public Schedule getSchedule(Long userId, Long calendarId, Long scheduleId) {
+	public ScheduleDto.Cached getScheduleFromCache(Long userId, Long calendarId, Long scheduleId) {
 		log.info("Calling getSchedule method for calendarId: {}, scheduleId: {}", calendarId, scheduleId);
 		validateCalendarMember(userId, calendarId);
 		validateSchedule(calendarId, scheduleId);
-		return scheduleRepository.findByIdAndCalendarId(scheduleId, calendarId)
+		Schedule schedule = scheduleRepository.findByIdAndCalendarId(scheduleId, calendarId)
 			.orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_FOUND));
+		return ScheduleDto.Cached.from(schedule);
 	}
+
+
+	@CachePut(value = "schedule", key = "#request.calendarId + ':' + #request.id")
+	public ScheduleDto.Cached updateScheduleFromCache(ScheduleDto.Request request) {
+		Schedule schedule = Cached.toEntity(getScheduleFromCache(request.getUserId(), request.getCalendarId(), request.getId()));
+
+		if (request.getTitle() != null) schedule.setTitle(request.getTitle());
+		if (request.getStartDate() != null) schedule.setStartDate(request.getStartDate());
+		if (request.getStartDate() != null) schedule.setEndDate(request.getEndDate());
+		if (request.getMemo() != null) schedule.setMemo(request.getMemo());
+		// TODO: 장소, To-do 추가
+
+		scheduleRepository.save(schedule);
+
+		return ScheduleDto.Cached.from(schedule);
+	}
+
 
 	/**
 	 * 주어진 userId와 calendarId에 대해 사용자가 해당 캘린더의 멤버인지 확인합니다.

--- a/src/main/java/com/zerobase/timate/service/ScheduleService.java
+++ b/src/main/java/com/zerobase/timate/service/ScheduleService.java
@@ -1,15 +1,15 @@
 package com.zerobase.timate.service;
 
+import static com.zerobase.timate.dto.ScheduleDto.Cached.toEntity;
 import static com.zerobase.timate.entity.PeriodType.DAILY;
 import static com.zerobase.timate.type.ErrorCode.INVALID_PERIOD;
-import static com.zerobase.timate.type.ErrorCode.SCHEDULE_NOT_FOUND;
 
+import com.zerobase.timate.dto.CalendarDto;
 import com.zerobase.timate.dto.ScheduleDto;
 import com.zerobase.timate.dto.ScheduleDto.Response;
 import com.zerobase.timate.entity.Calendar;
 import com.zerobase.timate.entity.PeriodType;
 import com.zerobase.timate.entity.Schedule;
-import com.zerobase.timate.entity.UserCalendar;
 import com.zerobase.timate.exception.ScheduleException;
 import com.zerobase.timate.repository.ScheduleRepository;
 import java.time.DayOfWeek;
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -35,20 +34,18 @@ public class ScheduleService {
 
 	private final ScheduleRepository scheduleRepository;
 
-	private final RedisTemplate<String, Object> redisTemplate;
-
 	@Transactional
 	public ScheduleDto.Response create(ScheduleDto.Request request) {
 		Long userId = request.getUserId();
 		Long calendarId = request.getCalendarId();
 
-		Calendar calendar = commonService.getCalendar(userId, calendarId);
+		Calendar calendar = CalendarDto.Cached.toEntity(commonService.getCalendarFromCache(userId, calendarId));
 
 		Schedule schedule = Schedule.of(request, calendar);
 		// TODO: 장소, To-do 추가
 		scheduleRepository.save(schedule);
 
-		return ScheduleDto.Response.from(schedule);
+		return ScheduleDto.Response.from(toEntity(commonService.getScheduleFromCache(userId, calendarId, schedule.getId())));
 	}
 
 	public Pair<LocalDate, LocalDate> getStartDateAndEndDate(LocalDate referenceDate, PeriodType period) {
@@ -96,31 +93,18 @@ public class ScheduleService {
 	}
 
 	public ScheduleDto.Response read(Long userId, Long calendarId, Long id) {
-		return ScheduleDto.Response.from(commonService.getSchedule(userId, calendarId, id));
+		return ScheduleDto.Response.from(toEntity(commonService.getScheduleFromCache(userId, calendarId, id)));
 	}
 
 	@Transactional
 	public ScheduleDto.Response update(ScheduleDto.Request request) {
-		Schedule schedule = commonService.getSchedule(request.getUserId(), request.getCalendarId(), request.getId());
-
-		if (request.getTitle() != null) schedule.setTitle(request.getTitle());
-		if (request.getStartDate() != null) schedule.setStartDate(request.getStartDate());
-		if (request.getStartDate() != null) schedule.setEndDate(request.getEndDate());
-		if (request.getMemo() != null) schedule.setMemo(request.getMemo());
-		// TODO: 장소, To-do 추가
-
-		scheduleRepository.save(schedule);
-
-		// @Cacheable 로 캐시 저장할 때와 반환 값이 달라서 redisTemplate 사용해 캐시 업데이트
-		redisTemplate.opsForValue().set("schedule::" + request.getCalendarId() + ":" + request.getId(), schedule);
-
-		return ScheduleDto.Response.from(schedule);
+		return ScheduleDto.Response.from(ScheduleDto.Cached.toEntity(commonService.updateScheduleFromCache(request)));
 	}
 
 	@Transactional
 	@CacheEvict(value = "schedule",  key = "#calendarId + ':' + #id")
 	public void delete(Long userId, Long calendarId, Long id) {
-		scheduleRepository.delete(commonService.getSchedule(userId, calendarId, id));
+		scheduleRepository.delete(toEntity(commonService.getScheduleFromCache(userId, calendarId, id)));
 	}
 
 }

--- a/src/main/java/com/zerobase/timate/service/ScheduleService.java
+++ b/src/main/java/com/zerobase/timate/service/ScheduleService.java
@@ -21,6 +21,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -33,14 +35,14 @@ public class ScheduleService {
 
 	private final ScheduleRepository scheduleRepository;
 
+	private final RedisTemplate<String, Object> redisTemplate;
 
 	@Transactional
 	public ScheduleDto.Response create(ScheduleDto.Request request) {
 		Long userId = request.getUserId();
 		Long calendarId = request.getCalendarId();
 
-		UserCalendar userCalendar = commonService.getUserCalendar(userId, calendarId);
-		Calendar calendar = userCalendar.getCalendar();
+		Calendar calendar = commonService.getCalendar(userId, calendarId);
 
 		Schedule schedule = Schedule.of(request, calendar);
 		// TODO: 장소, To-do 추가
@@ -66,7 +68,7 @@ public class ScheduleService {
 	public Map<?, List<Response>> getSchedulesByPeriod(
 		Long userId, Long calendarId, LocalDate referenceDate, PeriodType period) {
 
-		commonService.checkCalendarMember(userId, calendarId);
+		commonService.validateCalendarMember(userId, calendarId);
 
 		Pair<LocalDate, LocalDate> pair = getStartDateAndEndDate(referenceDate, period);
 		LocalDate startDate = pair.getLeft();
@@ -94,16 +96,12 @@ public class ScheduleService {
 	}
 
 	public ScheduleDto.Response read(Long userId, Long calendarId, Long id) {
-		commonService.checkCalendarMember(userId, calendarId);
-
-		return ScheduleDto.Response.from(getScheduleById(id));
+		return ScheduleDto.Response.from(commonService.getSchedule(userId, calendarId, id));
 	}
 
 	@Transactional
 	public ScheduleDto.Response update(ScheduleDto.Request request) {
-		commonService.checkCalendarMember(request.getUserId(), request.getCalendarId());
-
-		Schedule schedule = getScheduleById(request.getId());
+		Schedule schedule = commonService.getSchedule(request.getUserId(), request.getCalendarId(), request.getId());
 
 		if (request.getTitle() != null) schedule.setTitle(request.getTitle());
 		if (request.getStartDate() != null) schedule.setStartDate(request.getStartDate());
@@ -113,18 +111,16 @@ public class ScheduleService {
 
 		scheduleRepository.save(schedule);
 
+		// @Cacheable 로 캐시 저장할 때와 반환 값이 달라서 redisTemplate 사용해 캐시 업데이트
+		redisTemplate.opsForValue().set("schedule::" + request.getCalendarId() + ":" + request.getId(), schedule);
+
 		return ScheduleDto.Response.from(schedule);
 	}
 
 	@Transactional
-	public void delete(Long useId, Long calendarId, Long id) {
-		commonService.checkCalendarMaster(useId, calendarId);
-		scheduleRepository.delete(getScheduleById(id));
-	}
-
-	private Schedule getScheduleById(Long id) {
-		return scheduleRepository.findById(id).
-			orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_FOUND));
+	@CacheEvict(value = "schedule",  key = "#calendarId + ':' + #id")
+	public void delete(Long userId, Long calendarId, Long id) {
+		scheduleRepository.delete(commonService.getSchedule(userId, calendarId, id));
 	}
 
 }

--- a/src/test/java/com/zerobase/timate/cache/CacheableTest.java
+++ b/src/test/java/com/zerobase/timate/cache/CacheableTest.java
@@ -1,0 +1,112 @@
+package com.zerobase.timate.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.zerobase.timate.dto.CalendarDto;
+import com.zerobase.timate.entity.Calendar;
+import com.zerobase.timate.service.CalendarService;
+import com.zerobase.timate.service.CommonService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+
+@SpringBootTest
+class CacheableTest {
+
+	@Autowired
+    private CommonService commonService;
+
+    @Autowired
+    private CalendarService calendarService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    private Long userId;
+    private Long calendarId;
+
+    @BeforeEach
+    void setUp() {
+        userId = 18L;
+        calendarId = 1031L;
+    }
+
+    @Test
+    public void testCalendarCaching_read() {
+
+        // 첫번째 호출 - db 에서 호출, 캐시 저장
+        Calendar firstCall = commonService.getCalendar(userId, calendarId);
+        assertNotNull(firstCall);
+
+        // 두번째 호출 - 캐시 값 호출
+        Calendar secondCall = commonService.getCalendar(userId, calendarId);
+        assertNotNull(secondCall);
+
+        // 첫 번째와 두 번째 호출 결과가 동일해야 함
+        assertEquals(firstCall.getId(), secondCall.getId());
+        assertEquals(firstCall.getName(), secondCall.getName());
+
+        // CacheManager를 이용해 직접 캐시를 확인할 수 있음
+        Cache cache = cacheManager.getCache("calendar");
+        assertNotNull(cache);
+
+        Calendar cachedValue = cache.get(userId + ":" + calendarId, Calendar.class);
+        assertEquals(firstCall.getId(), cachedValue.getId());
+        assertEquals(firstCall.getName(), cachedValue.getName());
+    }
+
+	@Test
+    void testCacheHitPerformance() {
+
+        // 캐시 미스 테스트 (처음 호출)
+        long startTime = System.currentTimeMillis();
+        commonService.getUserCalendar(userId, calendarId); // DB에서 데이터를 조회해야 함
+        long firstCallDuration = System.currentTimeMillis() - startTime;
+
+        // 캐시 히트 테스트 (두 번째 호출)
+        startTime = System.currentTimeMillis();
+        commonService.getUserCalendar(userId, calendarId); // 캐시에서 데이터를 조회해야 함
+        long secondCallDuration = System.currentTimeMillis() - startTime;
+
+        // 첫 번째 호출보다 두 번째 호출이 빠르게 끝나야 함 (캐시 히트)
+        assertTrue(secondCallDuration < firstCallDuration, "The second call should be faster due to cache hit.");
+    }
+
+    @Test
+    public void testCalendarCaching_update() {
+
+        // 첫번째 호출 - db 에서 호출, 캐시 저장
+        Calendar firstCall = commonService.getCalendar(userId, calendarId);
+        assertNotNull(firstCall);
+
+        CalendarDto.Request request = new CalendarDto.Request();
+        request.setUserId(userId);
+        request.setId(calendarId);
+        request.setName(firstCall.getName() + 1);
+        // 캐시에도 수정된 값이 업데이트 되어야 함
+        calendarService.update(request);
+
+        // 두번째 호출 - 캐시 값 호출
+        Calendar secondCall = commonService.getCalendar(userId, calendarId);
+        assertNotNull(secondCall);
+
+        assertNotEquals(firstCall.getName(), secondCall.getName());
+
+        // CacheManager를 이용해 직접 캐시를 확인할 수 있음
+        Cache cache = cacheManager.getCache("calendar");
+        assertNotNull(cache);
+
+        Calendar cachedValue = cache.get(userId + ":" + calendarId, Calendar.class);
+        assertNotEquals(firstCall.getName(), cachedValue.getName());
+        assertEquals(secondCall.getId(), cachedValue.getId());
+    }
+
+
+}

--- a/src/test/java/com/zerobase/timate/cache/CacheableTest.java
+++ b/src/test/java/com/zerobase/timate/cache/CacheableTest.java
@@ -6,9 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.zerobase.timate.dto.CalendarDto;
-import com.zerobase.timate.entity.Calendar;
+import com.zerobase.timate.dto.ScheduleDto;
 import com.zerobase.timate.service.CalendarService;
 import com.zerobase.timate.service.CommonService;
+import com.zerobase.timate.service.ScheduleService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,17 +26,21 @@ class CacheableTest {
 
     @Autowired
     private CalendarService calendarService;
+    @Autowired
+    private ScheduleService scheduleService;
 
     @Autowired
     private CacheManager cacheManager;
 
     private Long userId;
     private Long calendarId;
+    private Long scheduleId;
 
     @BeforeEach
     void setUp() {
         userId = 18L;
         calendarId = 1034L;
+        scheduleId = 7L;
     }
 
     @Test
@@ -105,6 +110,60 @@ class CacheableTest {
 
         CalendarDto.Cached cachedValue = cache.get(userId + ":" + calendarId, CalendarDto.Cached.class);
         assertNotEquals(firstCall.getName(), cachedValue.getName());
+        assertEquals(secondCall.getId(), cachedValue.getId());
+    }
+
+    @Test
+    public void testScheduleCaching_read() {
+
+        // 첫번째 호출 - db 에서 호출, 캐시 저장
+        ScheduleDto.Cached firstCall = commonService.getScheduleFromCache(userId, calendarId, scheduleId);
+        assertNotNull(firstCall);
+
+        // 두번째 호출 - 캐시 값 호출
+        ScheduleDto.Cached secondCall = commonService.getScheduleFromCache(userId, calendarId, scheduleId);
+        assertNotNull(secondCall);
+
+        // 첫 번째와 두 번째 호출 결과가 동일해야 함
+        assertEquals(firstCall.getId(), secondCall.getId());
+        assertEquals(firstCall.getTitle(), secondCall.getTitle());
+
+        // CacheManager를 이용해 직접 캐시를 확인할 수 있음
+        Cache cache = cacheManager.getCache("schedule");
+        assertNotNull(cache);
+
+        ScheduleDto.Cached cachedValue = cache.get(calendarId + ":" + scheduleId, ScheduleDto.Cached.class);
+        assertEquals(firstCall.getId(), cachedValue.getId());
+        assertEquals(firstCall.getTitle(), cachedValue.getTitle());
+    }
+
+    @Test
+    public void testScheduleCaching_update() {
+
+        // 첫번째 호출 - db 에서 호출, 캐시 저장
+        ScheduleDto.Cached firstCall = commonService.getScheduleFromCache(userId, calendarId, scheduleId);
+        assertNotNull(firstCall);
+
+        ScheduleDto.Request request = new ScheduleDto.Request();
+        request.setUserId(userId);
+        request.setCalendarId(calendarId);
+        request.setId(scheduleId);
+        request.setTitle(firstCall.getTitle() + 1);
+        // 캐시에도 수정된 값이 업데이트 되어야 함
+        scheduleService.update(request);
+
+        // 두번째 호출 - 캐시 값 호출
+        ScheduleDto.Cached secondCall = commonService.getScheduleFromCache(userId, calendarId, scheduleId);
+        assertNotNull(secondCall);
+
+        assertNotEquals(firstCall.getTitle(), secondCall.getTitle());
+
+        // CacheManager를 이용해 직접 캐시를 확인할 수 있음
+        Cache cache = cacheManager.getCache("schedule");
+        assertNotNull(cache);
+
+        ScheduleDto.Cached cachedValue = cache.get(calendarId + ":" + scheduleId, ScheduleDto.Cached.class);
+        assertNotEquals(firstCall.getTitle(), cachedValue.getTitle());
         assertEquals(secondCall.getId(), cachedValue.getId());
     }
 

--- a/src/test/java/com/zerobase/timate/cache/CacheableTest.java
+++ b/src/test/java/com/zerobase/timate/cache/CacheableTest.java
@@ -35,18 +35,18 @@ class CacheableTest {
     @BeforeEach
     void setUp() {
         userId = 18L;
-        calendarId = 1031L;
+        calendarId = 1034L;
     }
 
     @Test
     public void testCalendarCaching_read() {
 
         // 첫번째 호출 - db 에서 호출, 캐시 저장
-        Calendar firstCall = commonService.getCalendar(userId, calendarId);
+        CalendarDto.Cached firstCall = commonService.getCalendarFromCache(userId, calendarId);
         assertNotNull(firstCall);
 
         // 두번째 호출 - 캐시 값 호출
-        Calendar secondCall = commonService.getCalendar(userId, calendarId);
+        CalendarDto.Cached secondCall = commonService.getCalendarFromCache(userId, calendarId);
         assertNotNull(secondCall);
 
         // 첫 번째와 두 번째 호출 결과가 동일해야 함
@@ -57,7 +57,7 @@ class CacheableTest {
         Cache cache = cacheManager.getCache("calendar");
         assertNotNull(cache);
 
-        Calendar cachedValue = cache.get(userId + ":" + calendarId, Calendar.class);
+        CalendarDto.Cached cachedValue = cache.get(userId + ":" + calendarId, CalendarDto.Cached.class);
         assertEquals(firstCall.getId(), cachedValue.getId());
         assertEquals(firstCall.getName(), cachedValue.getName());
     }
@@ -83,7 +83,7 @@ class CacheableTest {
     public void testCalendarCaching_update() {
 
         // 첫번째 호출 - db 에서 호출, 캐시 저장
-        Calendar firstCall = commonService.getCalendar(userId, calendarId);
+        CalendarDto.Cached firstCall = commonService.getCalendarFromCache(userId, calendarId);
         assertNotNull(firstCall);
 
         CalendarDto.Request request = new CalendarDto.Request();
@@ -94,7 +94,7 @@ class CacheableTest {
         calendarService.update(request);
 
         // 두번째 호출 - 캐시 값 호출
-        Calendar secondCall = commonService.getCalendar(userId, calendarId);
+        CalendarDto.Cached secondCall = commonService.getCalendarFromCache(userId, calendarId);
         assertNotNull(secondCall);
 
         assertNotEquals(firstCall.getName(), secondCall.getName());
@@ -103,7 +103,7 @@ class CacheableTest {
         Cache cache = cacheManager.getCache("calendar");
         assertNotNull(cache);
 
-        Calendar cachedValue = cache.get(userId + ":" + calendarId, Calendar.class);
+        CalendarDto.Cached cachedValue = cache.get(userId + ":" + calendarId, CalendarDto.Cached.class);
         assertNotEquals(firstCall.getName(), cachedValue.getName());
         assertEquals(secondCall.getId(), cachedValue.getId());
     }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**  
- `getCalendar()`, `getSchedule()` 메서드에 캐싱 처리가 되어있지 않음.  

**TO-BE**  
1. **Redis 캐시 설정**  
   - 라이브러리 추가:
     - `spring-boot-starter-cache`
     - `jackson-datatype-jsr310`
   - `@Cacheable` 어노테이션을 사용하여 캐시 저장.
   - 수정 요청 시 `RedisTemplate`을 사용하여 캐시를 업데이트:
     - `@Cacheable` 메서드의 반환 값은 `Calendar` / `Schedule` 객체.
     - 수정 요청 메서드의 반환 값은 `ResponseDto`이므로 `RedisTemplate`을 사용.
   - 삭제 요청 메서드에 `@CacheEvict` 추가:
     - 삭제 성공 시, 해당 캐시를 제거.
     - 단, 캐시 키가 사용자 ID + 캘린더 ID 조합이기 때문에 다른 사용자 ID의 캐시는 삭제되지 않음.
     - `redisTemplate.keys()`로 키 검색 및 삭제는 비효율적이므로, 캐시 유효시간(TTL)을 30분으로 설정하여 자동 삭제되도록 처리.

2. **Redis 설정**
   - `cacheManager` 설정: `@Cacheable` 사용 시 캐시 처리.
   - `redisTemplate` 설정: 수정 요청 시 직접 캐시 업데이트를 위해 사용.
   - 직렬화 설정: `GenericJackson2JsonRedisSerializer` 사용.
   - 캐시 TTL 설정: 30분.

3. **서비스 메서드 이름 변경**
   - `check~` 메서드를 `validate~`로 이름 변경.

4. **Schedule 엔티티 수정**
   - `Schedule` 엔티티의 `calendar_id` 필드에 누락된 cascade 설정 추가 (캘린더 삭제 시 연관된 일정 데이터 삭제).

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드  
  - **캐시 읽기 테스트 (`testCalendarCaching_read`)**:  
    - `commonService.getCalendar()` 메서드를 두 번 호출하여 동일한 결과 반환 확인.  
    - 두 번째 호출은 캐시에서 값을 가져와야 하며, DB 조회 없이 동일한 값 반환.  
    - `CacheManager`를 사용하여 캐시 저장소의 값 확인.  
  - **캐시 조회 성능 테스트 (`testCacheHitPerformance`)**:  
    - 첫 번째 호출은 캐시 미스로 인해 DB 조회.  
    - 두 번째 호출은 캐시 히트로 인해 빠르게 데이터 반환.  
    - 호출 시간 비교를 통해 캐시 성능 향상 검증.  
  - **캐시 업데이트 테스트 (`testCalendarCaching_update`)**:  
    - `commonService.getCalendar()` 호출 후, `calendarService.update()`를 사용하여 데이터 수정.  
    - 캐시 값도 함께 갱신되는지 확인하기 위해 수정된 값과 비교.  
    - `CacheManager`로 캐시를 다시 조회하여 수정된 값 반영 여부 확인.  
- [x] Redis에 값이 저장 및 삭제되는 것 확인 완료.

